### PR TITLE
feat(converters): Make DurationConverter more flexible

### DIFF
--- a/bot/cogs/moderation/silence.py
+++ b/bot/cogs/moderation/silence.py
@@ -27,7 +27,7 @@ class SilenceCog(commands.Cog):
     async def silence(
         self,
         ctx: commands.Context,
-        until: DurationConverter = datetime.now() + timedelta(minutes=15)
+        until: DurationConverter(default=timedelta(minutes=15))
     ) -> None:
         """
         Locks the channel for the specified time.

--- a/bot/cogs/moderation/silence.py
+++ b/bot/cogs/moderation/silence.py
@@ -27,7 +27,7 @@ class SilenceCog(commands.Cog):
     async def silence(
         self,
         ctx: commands.Context,
-        until: DurationConverter(default=timedelta(minutes=15))
+        until: DurationConverter = datetime.now() + timedelta(minutes=15)
     ) -> None:
         """
         Locks the channel for the specified time.

--- a/bot/cogs/moderation/silence.py
+++ b/bot/cogs/moderation/silence.py
@@ -125,7 +125,7 @@ class SilenceCog(commands.Cog):
 
     def _datetime_to_seconds(self, datetime_obj: datetime) -> int:
         """Converts a datetime object to seconds."""
-        return int(datetime_obj.strftime("%s"))
+        return int(datetime_obj.timestamp())
 
 
 def setup(bot: Bot) -> None:

--- a/bot/converters.py
+++ b/bot/converters.py
@@ -1,5 +1,5 @@
 import re
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import Optional
 
 import dateutil.parser
@@ -45,16 +45,6 @@ class DurationConverter(commands.Converter):
         r"(?:(?P<seconds>\d{1,5})s)?"
     )
 
-    def __init__(self, *, default: Optional[timedelta] = None):
-        """
-        Initialises the duration converter.
-
-        The optional `default` keyword argument is a `datetime.timedelta`
-        instance that represents the default duration span to return in
-        case an invalid duration string was provided by a user.
-        """
-        self.default = default
-
     async def convert(
         self,
         ctx: commands.Context,
@@ -64,18 +54,12 @@ class DurationConverter(commands.Converter):
         Converts a duration string into a `datetime.datetime` object.
 
         Example of a duration string: 1h2m3s
-
-        If an invalid duration string was provided and a default timedelta
-        was specified, the default timedelta will be used instead.
         """
         match = self.compiled.fullmatch(duration_str)
         if match is None or not match.group(0):
-            if self.default is not None:
-                return datetime.now() + self.default
-            else:
-                raise commands.BadArgument(
-                    f'Invalid duration string provided: "{duration_str}"'
-                )
+            raise commands.BadArgument(
+                f'Invalid duration provided: "{duration_str}"'
+            )
 
         duration_dict = {
             k: int(v)

--- a/bot/converters.py
+++ b/bot/converters.py
@@ -46,6 +46,12 @@ class DurationConverter(commands.Converter):
     )
 
     def __init__(self, *, default: Optional[timedelta] = None):
+        """
+        Initialises the duration converter. The optional `default` keyword
+        argument is a `datetime.timedelta` instance that represents the
+        default duration span to return in case an invalid duration string
+        was provided by a user.
+        """
         self.default = default
 
     async def convert(

--- a/bot/converters.py
+++ b/bot/converters.py
@@ -1,6 +1,5 @@
 import re
 from datetime import datetime
-from typing import Optional
 
 import dateutil.parser
 import dateutil.tz
@@ -49,7 +48,7 @@ class DurationConverter(commands.Converter):
         self,
         ctx: commands.Context,
         duration_str: str
-    ) -> int:
+    ) -> datetime:
         """
         Converts a duration string into a `datetime.datetime` object.
 

--- a/bot/converters.py
+++ b/bot/converters.py
@@ -47,10 +47,11 @@ class DurationConverter(commands.Converter):
 
     def __init__(self, *, default: Optional[timedelta] = None):
         """
-        Initialises the duration converter. The optional `default` keyword
-        argument is a `datetime.timedelta` instance that represents the
-        default duration span to return in case an invalid duration string
-        was provided by a user.
+        Initialises the duration converter.
+
+        The optional `default` keyword argument is a `datetime.timedelta`
+        instance that represents the default duration span to return in
+        case an invalid duration string was provided by a user.
         """
         self.default = default
 


### PR DESCRIPTION
* The compiled duration regex is now attached to the class, rather than being compiled every time the converter is run
* Months and days have been added as valid duration units, as well as making the allowed duration values a little stricter
* The actual converter itself has been simplified, using `dateutil.relativedelta.relativedelta` to avoid reinventing the wheel
* Now, `_datetime_to_seconds` uses `int(datetime_obj.timestamp())` instead of getting its representation in seconds as a string and then converting it to an int.