### PR TITLE
Support case insensitive extension format

### DIFF
--- a/bot/cogs/antivirus.py
+++ b/bot/cogs/antivirus.py
@@ -32,7 +32,7 @@ class AntiMalwareCog(commands.Cog):
 
         for attachment in message.attachments:
             _, extension = splitext(attachment.url)
-            if extension not in WhitelistedFileExtensions.whitelist:
+            if extension.lower() not in WhitelistedFileExtensions.whitelist:
                 break
         else:
             return


### PR DESCRIPTION
The reason that supports is that when trying to send with .PNG instead of .png.
![image](https://cdn.discordapp.com/attachments/498915129732366357/760949168923213864/Screenshot_20200930-223014_Discord.jpg)